### PR TITLE
Add basic auth API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=board
+SESSION_SECRET=your-secret
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-node_modules/ 
-.env 
-npm-debug.log 
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Node.js Bulletin Board API
+
+This project provides a simple JSON API for user registration, login and logout.
+It uses MySQL with `mysql2` and stores session information using `express-session`.
+Passwords are hashed with `bcrypt`.
+
+## Setup
+
+1. Create a MySQL database and a `users` table:
+   ```sql
+   CREATE TABLE users (
+     id INT AUTO_INCREMENT PRIMARY KEY,
+     username VARCHAR(255) UNIQUE NOT NULL,
+     password VARCHAR(255) NOT NULL,
+     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+   );
+   ```
+2. Copy `.env.example` to `.env` and set database credentials and session secret.
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Start the server:
+   ```bash
+   npm start
+   ```
+
+The authentication routes are available under `/auth`:
+- `POST /auth/register`
+- `POST /auth/login`
+- `POST /auth/logout`

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const session = require('express-session');
+const cookieParser = require('cookie-parser');
+const authRoutes = require('./routes/authRoutes');
+const errorHandler = require('./middlewares/errorHandler');
+require('dotenv').config();
+
+const app = express();
+
+app.use(express.json());
+app.use(cookieParser());
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'secret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+app.use('/auth', authRoutes);
+
+app.use(errorHandler);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/config/db.js
+++ b/src/config/db.js
@@ -1,0 +1,14 @@
+const mysql = require('mysql2/promise');
+require('dotenv').config();
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'localhost',
+  user: process.env.DB_USER || 'root',
+  password: process.env.DB_PASSWORD || '',
+  database: process.env.DB_NAME || 'board',
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0
+});
+
+module.exports = pool;

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,0 +1,46 @@
+const bcrypt = require('bcrypt');
+const userModel = require('../models/userModel');
+
+exports.register = async (req, res, next) => {
+  try {
+    const { username, password } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Username and password required' });
+    }
+    const existing = await userModel.findByUsername(username);
+    if (existing) {
+      return res.status(409).json({ error: 'User already exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const userId = await userModel.createUser(username, hashed);
+    req.session.userId = userId;
+    res.status(201).json({ message: 'User registered' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.login = async (req, res, next) => {
+  try {
+    const { username, password } = req.body;
+    const user = await userModel.findByUsername(username);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    req.session.userId = user.id;
+    res.json({ message: 'Logged in' });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.logout = (req, res) => {
+  req.session.destroy(() => {
+    res.clearCookie('connect.sid');
+    res.json({ message: 'Logged out' });
+  });
+};

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -1,0 +1,6 @@
+exports.isAuthenticated = (req, res, next) => {
+  if (req.session && req.session.userId) {
+    return next();
+  }
+  res.status(401).json({ error: 'Unauthorized' });
+};

--- a/src/middlewares/errorHandler.js
+++ b/src/middlewares/errorHandler.js
@@ -1,0 +1,4 @@
+module.exports = (err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+};

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -1,0 +1,16 @@
+const db = require('../config/db');
+
+async function createUser(username, password) {
+  const [result] = await db.execute(
+    'INSERT INTO users (username, password) VALUES (?, ?)',
+    [username, password]
+  );
+  return result.insertId;
+}
+
+async function findByUsername(username) {
+  const [rows] = await db.execute('SELECT * FROM users WHERE username = ?', [username]);
+  return rows[0];
+}
+
+module.exports = { createUser, findByUsername };

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const authController = require('../controllers/authController');
+
+router.post('/register', authController.register);
+router.post('/login', authController.login);
+router.post('/logout', authController.logout);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement MySQL connection and user model
- build auth controller, routes and middleware
- add express app with session support
- document setup and environment variables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684050f0103c832c919e60ca835c115d